### PR TITLE
Add prompt to confirm disconnection if Bluetooth device is already co…

### DIFF
--- a/btmenu
+++ b/btmenu
@@ -61,6 +61,30 @@ execute_mode() {
     [[ $name ]] || return
     mac=${DEVICES["$name"]}
 
+
+    # Check if the device is already connected
+    if printf 'info %s\n' "$mac" | _bluetoothctl | grep -Pq '^[\t ]+Connected: yes'; then
+        # Prompt to disconnect if already connected
+        if echo -e "yes\nno" | dmenu -p "$name is already connected. Disconnect?" | grep -q "^yes$"; then
+            mode=disconnect
+        else
+            notify "Cancelled disconnecting from $name"
+            return 0
+        fi
+    fi
+
+    case $mode in
+        connect)
+            preposition=to
+            expected_to_connect=yes
+        ;;
+        disconnect)
+            preposition=from
+            expected_to_connect=no
+        ;;
+    esac
+
+
     notify "Attempting to $mode $preposition $name"
 
     while (( retries-- )); do


### PR DESCRIPTION
…nnected

- Added logic to check if a selected Bluetooth device is currently connected.
- If the device is connected, prompt the user with a confirmation dialog via dmenu.
- If the user confirms, the script switches to disconnect mode and disconnects the device.
- If the user cancels, the disconnection process is aborted.